### PR TITLE
Update webhook URLs and deployment values in YAML configurations

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -115,7 +115,7 @@ jobs:
     steps:
       - name: Trigger n8n Deploy Webhook
         run: |
-          curl --location --fail-with-body --request POST 'https://webhook.eng.sdc.nycu.club/webhook/deploy' \
+          curl --location --fail-with-body --request POST 'https://webhook.sdc.nycu.club/webhook/deploy' \
             --header 'Content-Type: application/json' \
             --header "x-deploy-token: ${{ secrets.N8N_DEPLOY_TOKEN }}" \
             --data-raw '{
@@ -139,7 +139,7 @@ jobs:
                 "enable": true,
                 "title": "Endpoint",
                 "name": "dev.core-system.sdc.nycu.club",
-                "value": "gcp-eng-deploy:internal"
+                "value": "default-eng-deploy:internal"
               }
             }
           }'

--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -128,7 +128,7 @@ jobs:
 
       - name: Trigger n8n Snapshot Webhook
         run: |
-          curl --location --fail-with-body -X POST https://webhook.eng.sdc.nycu.club/webhook/deploy \
+          curl --location --fail-with-body -X POST https://webhook.sdc.nycu.club/webhook/deploy \
             -H "Content-Type: application/json" \
             -H "x-deploy-token: ${{ secrets.N8N_DEPLOY_TOKEN }}" \
             -d '{
@@ -156,7 +156,7 @@ jobs:
                   "enable": true,
                   "title": "Endpoint",
                   "name": "pr-${{ github.event.pull_request.number }}.core-system.sdc.nycu.club",
-                  "value": "gcp-eng-deploy:internal"
+                  "value": "default-eng-deploy:internal"
                 }
               }
             }'

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"dev": "vite",
 		"build": "tsc -b && vite build",
-		"lint": "eslint .",
+		"lint": "eslint . && tsc --noemit",
 		"preview": "vite preview",
 		"format": "prettier --write ."
 	},

--- a/src/lib/request/api.ts
+++ b/src/lib/request/api.ts
@@ -1,14 +1,13 @@
 const BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
 export async function api<T>(path: string, options: RequestInit = {}): Promise<T> {
-	if (!options.headers["Content-Type"])
-		options.headers["Content-Type"] = "application/json";
+	if (!options.headers["Content-Type"]) options.headers["Content-Type"] = "application/json";
 
 	const res = await fetch(`${BASE_URL}${path}`, {
 		...options,
 		headers: {
 			"Content-Type": "application/json",
-			...options.headers,
+			...options.headers
 		}
 	});
 

--- a/src/lib/request/api.ts
+++ b/src/lib/request/api.ts
@@ -1,8 +1,6 @@
 const BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
 export async function api<T>(path: string, options: RequestInit = {}): Promise<T> {
-	if (!options.headers["Content-Type"]) options.headers["Content-Type"] = "application/json";
-
 	const res = await fetch(`${BASE_URL}${path}`, {
 		...options,
 		headers: {


### PR DESCRIPTION
## Type of changes
- CI

## Purpose
- Update deployment workflow to change the deployment target from GCP to the SDC office (EC029)

## Additional Information
- Update webhook and setup_domain
  - Webhook: https://webhook.eng.sdc.nycu.club/webhook/deploy → https://webhook.sdc.nycu.club/webhook/deploy
  - setup_domain: gcp-eng-deploy:internal → default-eng-deploy:internal
